### PR TITLE
Fix to getWarnings when two open channels from the same node have warnings

### DIFF
--- a/backend/src/main/java/de/cotto/lndmanagej/service/NodeWarningsService.java
+++ b/backend/src/main/java/de/cotto/lndmanagej/service/NodeWarningsService.java
@@ -43,6 +43,7 @@ public class NodeWarningsService {
     public Map<Node, NodeWarnings> getNodeWarnings() {
         return channelService.getOpenChannels().parallelStream()
                 .map(LocalChannel::getRemotePubkey)
+                .distinct()
                 .map(pubkey -> new AbstractMap.SimpleEntry<>(pubkey, getNodeWarnings(pubkey)))
                 .filter(this::hasWarnings)
                 .map(entry -> new AbstractMap.SimpleEntry<>(nodeService.getNode(entry.getKey()), entry.getValue()))

--- a/backend/src/test/java/de/cotto/lndmanagej/service/ChannelWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/ChannelWarningsServiceTest.java
@@ -16,6 +16,7 @@ import static de.cotto.lndmanagej.model.ChannelIdFixtures.CHANNEL_ID;
 import static de.cotto.lndmanagej.model.ChannelIdFixtures.CHANNEL_ID_4;
 import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL;
 import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL_TO_NODE_3;
+import static de.cotto.lndmanagej.model.warnings.ChannelWarningFixtures.CHANNEL_BALANCE_FLUCTUATION_WARNING;
 import static de.cotto.lndmanagej.model.warnings.ChannelWarningFixtures.CHANNEL_NUM_UPDATES_WARNING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -73,5 +74,17 @@ class ChannelWarningsServiceTest {
         assertThat(channelWarningsService.getChannelWarnings()).containsExactlyInAnyOrderEntriesOf(Map.of(
                 LOCAL_OPEN_CHANNEL, new ChannelWarnings(CHANNEL_NUM_UPDATES_WARNING)
         ));
+    }
+
+    @Test
+    void getChannelWarnings_two_different_warnings_for_same_channel() {
+        when(channelService.getOpenChannels()).thenReturn(Set.of(LOCAL_OPEN_CHANNEL));
+        when(provider1.getChannelWarnings(CHANNEL_ID)).thenReturn(Stream.of(CHANNEL_NUM_UPDATES_WARNING));
+        when(provider2.getChannelWarnings(CHANNEL_ID)).thenReturn(Stream.of(CHANNEL_BALANCE_FLUCTUATION_WARNING));
+        ChannelWarnings expectedWarnings =
+                new ChannelWarnings(CHANNEL_NUM_UPDATES_WARNING, CHANNEL_BALANCE_FLUCTUATION_WARNING);
+        assertThat(channelWarningsService.getChannelWarnings()).containsEntry(
+                LOCAL_OPEN_CHANNEL, expectedWarnings
+        );
     }
 }

--- a/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
@@ -99,9 +99,9 @@ class NodeWarningsServiceTest {
     void getNodeWarnings_duplicate_nodes() {
         when(channelService.getOpenChannels()).thenReturn(Set.of(LOCAL_OPEN_CHANNEL, LOCAL_OPEN_CHANNEL_2));
         when(provider1.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
-        when(provider2.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
+        when(provider2.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_PERCENTAGE_WARNING));
         assertThat(nodeWarningsService.getNodeWarnings()).containsExactlyInAnyOrderEntriesOf(Map.of(
-                NODE_2, new NodeWarnings(NODE_ONLINE_CHANGES_WARNING)
+                NODE_2, new NodeWarnings(NODE_ONLINE_CHANGES_WARNING, NODE_ONLINE_PERCENTAGE_WARNING)
         ));
     }
 }

--- a/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
@@ -100,8 +100,8 @@ class NodeWarningsServiceTest {
         when(channelService.getOpenChannels()).thenReturn(Set.of(LOCAL_OPEN_CHANNEL, LOCAL_OPEN_CHANNEL_2));
         when(provider1.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
         when(provider2.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_PERCENTAGE_WARNING));
-        assertThat(nodeWarningsService.getNodeWarnings()).containsExactlyInAnyOrderEntriesOf(Map.of(
+        assertThat(nodeWarningsService.getNodeWarnings()).containsEntry(
                 NODE_2, new NodeWarnings(NODE_ONLINE_CHANGES_WARNING, NODE_ONLINE_PERCENTAGE_WARNING)
-        ));
+        );
     }
 }

--- a/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
@@ -96,7 +96,7 @@ class NodeWarningsServiceTest {
     }
 
     @Test
-    void getNodeWarnings_duplicate_nodes() {
+    void getNodeWarnings_two_different_warnings_for_same_node() {
         when(channelService.getOpenChannels()).thenReturn(Set.of(LOCAL_OPEN_CHANNEL, LOCAL_OPEN_CHANNEL_2));
         when(provider1.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
         when(provider2.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_PERCENTAGE_WARNING));

--- a/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
@@ -12,8 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL;
-import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL_TO_NODE_3;
+import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.*;
 import static de.cotto.lndmanagej.model.NodeFixtures.NODE_2;
 import static de.cotto.lndmanagej.model.NodeFixtures.NODE_3;
 import static de.cotto.lndmanagej.model.PubkeyFixtures.PUBKEY_2;
@@ -91,6 +90,16 @@ class NodeWarningsServiceTest {
         assertThat(nodeWarningsService.getNodeWarnings()).containsExactlyInAnyOrderEntriesOf(Map.of(
                 NODE_2, new NodeWarnings(NODE_ONLINE_PERCENTAGE_WARNING),
                 NODE_3, new NodeWarnings(NODE_ONLINE_CHANGES_WARNING)
+        ));
+    }
+
+    @Test
+    void getNodeWarnings_duplicate_nodes() {
+        when(channelService.getOpenChannels()).thenReturn(Set.of(LOCAL_OPEN_CHANNEL, LOCAL_OPEN_CHANNEL_2));
+        when(provider1.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
+        when(provider2.getNodeWarnings(PUBKEY_2)).thenReturn(Stream.of(NODE_ONLINE_CHANGES_WARNING));
+        assertThat(nodeWarningsService.getNodeWarnings()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                NODE_2, new NodeWarnings(NODE_ONLINE_CHANGES_WARNING)
         ));
     }
 }

--- a/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
+++ b/backend/src/test/java/de/cotto/lndmanagej/service/NodeWarningsServiceTest.java
@@ -12,7 +12,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.*;
+import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL;
+import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL_2;
+import static de.cotto.lndmanagej.model.LocalOpenChannelFixtures.LOCAL_OPEN_CHANNEL_TO_NODE_3;
 import static de.cotto.lndmanagej.model.NodeFixtures.NODE_2;
 import static de.cotto.lndmanagej.model.NodeFixtures.NODE_3;
 import static de.cotto.lndmanagej.model.PubkeyFixtures.PUBKEY_2;


### PR DESCRIPTION
Fix for https://github.com/C-Otto/lnd-manageJ/issues/68