### PR TITLE
Remove version reference from layout.html for bootstrap css

### DIFF
--- a/platform/build.gradle.kts
+++ b/platform/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
         api("org.eclipse.collections:eclipse-collections:11.1.0")
         api("org.ini4j:ini4j:0.5.4")
         api("org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion")
-        api("org.webjars:bootstrap:5.2.2") // also edit version in layout.html
+        api("org.webjars:bootstrap:5.2.2")
         api("org.webjars:webjars-locator:0.45")
         api("uk.org.lidalia:slf4j-test:1.2.0")
     }

--- a/ui/src/main/resources/templates/fragments/layout.html
+++ b/ui/src/main/resources/templates/fragments/layout.html
@@ -11,7 +11,7 @@
     <title>lnd-manageJ</title>
 
     <link rel="shortcut icon" type="image/x-icon" th:href="@{/images/favicon.png}">
-    <link th:rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.2/css/bootstrap.min.css} "/>
+    <link th:rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css} "/>
     <link rel="stylesheet" th:href="@{/css/layout.css}"/>
     <link rel="stylesheet" th:href="@{/css/main.css}"/>
 </head>


### PR DESCRIPTION
After doing some research based on the comment https://github.com/C-Otto/lnd-manageJ/pull/73#issuecomment-1301008148
I found that the version can be removed. This project already uses webjars for including bootstrap and is already including the webjars locator which will resolve the correct version when one is not provided. This is already being used for the bootstrap javascript file.

I tested it locally and it resolves to the 5.2.2 version.